### PR TITLE
Color spaces implementation

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -182,30 +182,30 @@ mr::Vec3f rotated_point = point * q1;
 ### Color
 Initialization
 ```cpp
-mr::Color c1; // same as Vec4f(0, 0, 0, 0)
-mr::Color c2 = mr::Color(0.3, 0.47, 0.8); // == (0.3, 0.47, 0.8, 1.0)
-mr::Color c3 = mr::Color(76, 119, 204, 255); // == (0.2980392156862745, 0.4666666666666667, 0.8, 1.0)
-mr::Color c4 = mr::Color(0x4C'77'CC'FF); // == (0.2980392156862745, 0.4666666666666667, 0.8, 1.0)
-mr::Color c5 = 0x4C'77'CC'FF_rgba; // == (0.2980392156862745, 0.4666666666666667, 0.8, 1.0)
+mr::RGBAColor c1; // same as Vec4f(0, 0, 0, 0)
+mr::RGBAColor c2 = mr::Color(0.3, 0.47, 0.8); // == (0.3, 0.47, 0.8, 1.0)
+mr::RGBAColor c3 = mr::Color(76, 119, 204, 255); // == (0.2980392156862745, 0.4666666666666667, 0.8, 1.0)
+mr::RGBAColor c4 = mr::Color(0x4C'77'CC'FF); // == (0.2980392156862745, 0.4666666666666667, 0.8, 1.0)
+mr::RGBAColor c5 = 0x4C'77'CC'FF_rgba; // == (0.2980392156862745, 0.4666666666666667, 0.8, 1.0)
 ```
 Formats
 ```cpp
-mr::Color c6 = 0x4C'77'CC'FF_rgba;
-mr::Color c7 = color.argb(); // == 0xFF'4C'77'CC_rgba
-mr::Color c8 = color.bgra(); // == 0xCC'77'4c'FF_rgba
-mr::Color c9 = color.abgr(); // == 0xFF'CC'77'4c_rgba
+mr::RGBAColor c6 = 0x4C'77'CC'FF_rgba;
+mr::RGBAColor c7 = color.argb(); // == 0xFF'4C'77'CC_rgba
+mr::RGBAColor c8 = color.bgra(); // == 0xCC'77'4c'FF_rgba
+mr::RGBAColor c9 = color.abgr(); // == 0xFF'CC'77'4c_rgba
 ```
 Operations
 - comparison
 ```cpp
-mr::Color c10 = 0x4C'77'CC'FF_rgba;
-mr::Color copy = c10;
+mr::RGBAColor c10 = 0x4C'77'CC'FF_rgba;
+mr::RGBAColor copy = c10;
 
 bool is_equal = c10 == copy; // == true
 ```
 - sum
 ```cpp
-mr::Color c11 = mr::Color(1.0, 0.0, 0.5, 1.0) + mr::Color(0.0, 1.0, 0.5, 1.0); // == mr::Color(1.0, 1.0, 1.0, 2.0));
+mr::RGBAColor c11 = mr::Color(1.0, 0.0, 0.5, 1.0) + mr::Color(0.0, 1.0, 0.5, 1.0); // == mr::Color(1.0, 1.0, 1.0, 2.0));
 ```
 
 ### Useful stuff

--- a/include/mr-math/color.hpp
+++ b/include/mr-math/color.hpp
@@ -112,7 +112,7 @@ inline namespace math {
 
 namespace literals {
 
-  inline RGBAColor operator"" _rgba(unsigned long long value) {
+  inline RGBAColor operator""_rgba(unsigned long long value) {
     assert(value <= 0xFF'FF'FF'FF);
     return RGBAColor{static_cast<uint32_t>(value)};
   }

--- a/include/mr-math/color.hpp
+++ b/include/mr-math/color.hpp
@@ -2,13 +2,74 @@
 #define __MR_COLOR_HPP_
 
 #include "def.hpp"
+#include "mr-math/matr.hpp"
 #include "vec.hpp"
 
 namespace mr {
 inline namespace math {
+  // forward declarations
+  struct RGBAColor;
+  struct HSVAColor;
+  struct HSLAColor;
+  struct CMYKColor;
+  struct OKLABColor;
+
+  template <typename InputT, typename OutputT>
+    OutputT convert(InputT input) {
+      static_assert(false, "You have to specify this function for your particular types");
+    }
+
+  template <typename ColorDerived>
+  struct ColorBase {
+  public:
+    using ValueT = float;
+
+    // structured binding support
+    template <size_t I> requires (I < 4)
+      ValueT get(this const ColorDerived &self) { return self._data[I]; }
+
+    operator Vec3f(this ColorDerived &self) noexcept {
+      return (Vec3f)self._data;
+    }
+
+    operator Vec4f(this ColorDerived &self) noexcept {
+      return self._data;
+    }
+
+    friend ColorDerived operator+(ColorDerived lhs, const ColorDerived &rhs) noexcept {
+      lhs += rhs;
+      return lhs;
+    }
+
+    ColorDerived &operator+=(const ColorDerived &other) noexcept {
+      static_cast<ColorDerived*>(this)->_data += other._data;
+      return *(ColorDerived*)this;
+    }
+
+    bool operator==(this const ColorDerived &self, const ColorDerived &other) noexcept {
+      return self._data == other._data;
+    }
+
+    bool equal(this const ColorDerived &self, const ColorDerived &other, ValueT eps = epsilon<ValueT>()) noexcept {
+      return self._data.equal(other._data, eps);
+    }
+
+    friend std::ostream & operator<<(std::ostream &s, const ColorDerived &color) noexcept {
+      Vec4u comps = color._data * 255;
+      comps.clamp(0, 256);
+      s << '#' << std::hex << std::uppercase << comps[0] << comps[1] << comps[2] << comps[3] << std::nouppercase << std::dec;
+      return s;
+    }
+
+  };
 
   // color in RGBA float format
-  struct [[nodiscard]] RGBAColor {
+  struct [[nodiscard]] RGBAColor : ColorBase<RGBAColor> {
+    friend class ColorBase<RGBAColor>;
+
+  private:
+    Vec4f _data;
+
   public:
     using ValueT = float;
 
@@ -16,14 +77,14 @@ inline namespace math {
 
     template <std::floating_point T>
       RGBAColor(T r, T g, T b, T a = 1) noexcept
-        : _data{Vec4f{r, g, b, a}} {}
+        : _data(r, g, b, a) {}
 
     RGBAColor(Vec4f rgba) noexcept
-      : _data{rgba} {}
+      : _data(rgba) {}
 
     template <std::integral T>
       RGBAColor(T r, T g, T b, T a = 255) noexcept
-        : _data{r, g, b, a} {
+        : _data(r, g, b, a) {
         assert(r <= 255);
         assert(g <= 255);
         assert(b <= 255);
@@ -59,14 +120,6 @@ inline namespace math {
       return _data[i];
     }
 
-    // structured binding support
-    template <size_t I> requires (I < 4)
-      ValueT get() const { return _data[I]; }
-
-    operator Vec4f() noexcept {
-      return _data;
-    }
-
     // format conversions
     // TODO: implement using shuffle
     Vec4f argb() const noexcept {
@@ -80,35 +133,101 @@ inline namespace math {
     Vec4f abgr() const noexcept {
       return {a(), b(), g(), r()};
     }
+  };
 
-    friend RGBAColor operator+(RGBAColor lhs, const RGBAColor &rhs) noexcept {
-      lhs += rhs;
-      return lhs;
-    }
-
-    RGBAColor &operator+=(const RGBAColor &other) noexcept {
-      _data += other._data;;
-      return *this;
-    }
-
-    bool operator==(const RGBAColor &other) const noexcept {
-      return _data == other._data;
-    }
-
-    bool equal(const RGBAColor &other, ValueT eps = epsilon<ValueT>()) const noexcept {
-      return _data.equal(other._data, eps);
-    }
-
-    friend std::ostream & operator<<(std::ostream &s, const RGBAColor &color) noexcept {
-      Vec4u comps = color._data * 255;
-      comps.clamp(0, 256);
-      s << '#' << std::hex << std::uppercase << comps[0] << comps[1] << comps[2] << comps[3] << std::nouppercase << std::dec;
-      return s;
-    }
+  struct HSLAColor {
+    friend class ColorBase<HSLAColor>;
 
   private:
     Vec4f _data;
+
+  public:
+    using ValueT = float;
+
+    HSLAColor() = default;
   };
+
+  struct HSVAColor {
+    friend class ColorBase<HSVAColor>;
+
+  private:
+    Vec4f _data;
+
+  public:
+    using ValueT = float;
+
+    HSVAColor() = default;
+  };
+
+  struct CMYKColor {
+    friend class ColorBase<CMYKColor>;
+
+  private:
+    Vec4f _data;
+
+  public:
+    using ValueT = float;
+
+    CMYKColor() = default;
+  };
+
+  struct OKLABColor {
+    friend class ColorBase<OKLABColor>;
+
+  private:
+    Vec4f _data;
+
+  public:
+    using ValueT = float;
+
+    OKLABColor() = default;
+
+    template <std::floating_point T>
+      OKLABColor(T r, T g, T b, T a = 1) noexcept
+        : _data(r, g, b, a) {}
+
+    OKLABColor(Vec4f rgba) noexcept
+      : _data(rgba) {}
+
+    template <std::integral T>
+      OKLABColor(T r, T g, T b, T a = 255) noexcept
+        : _data(r, g, b, a) {
+        assert(r <= 255);
+        assert(g <= 255);
+        assert(b <= 255);
+        assert(a <= 255);
+        _data /= 255;
+      }
+
+    explicit OKLABColor(uint32_t rgba) noexcept
+      : OKLABColor(
+        uint8_t((rgba & 0xFF'00'00'00) >> 24),
+        uint8_t((rgba & 0x00'FF'00'00) >> 16),
+        uint8_t((rgba & 0x00'00'FF'00) >> 8),
+        uint8_t((rgba & 0x00'00'00'FF))
+      ) {}
+  };
+
+  template <>
+    inline OKLABColor convert<RGBAColor, OKLABColor>(RGBAColor rgba) {
+      auto v = static_cast<Vec3f>(rgba) * Matr3f {
+        Matr3f::RowT {0.4122214708f, 0.2119034982f, 0.0883024619f},
+        Matr3f::RowT {0.5363325363f, 0.6806995451f, 0.2817188376f},
+        Matr3f::RowT {0.0514459929f, 0.1073969566f, 0.6299787005f},
+      };
+
+      // TODO: rewrite using mr-math adaptation of <cmath>
+      float l_ = cbrtf(v[0]);
+      float m_ = cbrtf(v[1]);
+      float s_ = cbrtf(v[2]);
+
+      return {
+          0.2104542553f * l_ + 0.7936177850f * m_ - 0.0040720468f * s_,
+          1.9779984951f * l_ - 2.4285922050f * m_ + 0.4505937099f * s_,
+          0.0259040371f * l_ + 0.7827717662f * m_ - 0.8086757660f * s_,
+          rgba.a()
+      };
+    }
 
 namespace literals {
 

--- a/include/mr-math/color.hpp
+++ b/include/mr-math/color.hpp
@@ -8,21 +8,21 @@ namespace mr {
 inline namespace math {
 
   // color in RGBA float format
-  struct [[nodiscard]] Color {
+  struct [[nodiscard]] RGBAColor {
   public:
     using ValueT = float;
 
-    Color() = default;
+    RGBAColor() = default;
 
     template <std::floating_point T>
-      Color(T r, T g, T b, T a = 1) noexcept
+      RGBAColor(T r, T g, T b, T a = 1) noexcept
         : _data{Vec4f{r, g, b, a}} {}
 
-    Color(Vec4f rgba) noexcept
+    RGBAColor(Vec4f rgba) noexcept
       : _data{rgba} {}
 
     template <std::integral T>
-      Color(T r, T g, T b, T a = 255) noexcept
+      RGBAColor(T r, T g, T b, T a = 255) noexcept
         : _data{r, g, b, a} {
         assert(r <= 255);
         assert(g <= 255);
@@ -31,8 +31,8 @@ inline namespace math {
         _data /= 255;
       }
 
-    explicit Color(uint32_t rgba) noexcept
-      : Color(
+    explicit RGBAColor(uint32_t rgba) noexcept
+      : RGBAColor(
         uint8_t((rgba & 0xFF'00'00'00) >> 24),
         uint8_t((rgba & 0x00'FF'00'00) >> 16),
         uint8_t((rgba & 0x00'00'FF'00) >> 8),
@@ -81,25 +81,25 @@ inline namespace math {
       return {a(), b(), g(), r()};
     }
 
-    friend Color operator+(Color lhs, const Color &rhs) noexcept {
+    friend RGBAColor operator+(RGBAColor lhs, const RGBAColor &rhs) noexcept {
       lhs += rhs;
       return lhs;
     }
 
-    Color &operator+=(const Color &other) noexcept {
+    RGBAColor &operator+=(const RGBAColor &other) noexcept {
       _data += other._data;;
       return *this;
     }
 
-    bool operator==(const Color &other) const noexcept {
+    bool operator==(const RGBAColor &other) const noexcept {
       return _data == other._data;
     }
 
-    bool equal(const Color &other, ValueT eps = epsilon<ValueT>()) const noexcept {
+    bool equal(const RGBAColor &other, ValueT eps = epsilon<ValueT>()) const noexcept {
       return _data.equal(other._data, eps);
     }
 
-    friend std::ostream & operator<<(std::ostream &s, const Color &color) noexcept {
+    friend std::ostream & operator<<(std::ostream &s, const RGBAColor &color) noexcept {
       Vec4u comps = color._data * 255;
       comps.clamp(0, 256);
       s << '#' << std::hex << std::uppercase << comps[0] << comps[1] << comps[2] << comps[3] << std::nouppercase << std::dec;
@@ -112,9 +112,9 @@ inline namespace math {
 
 namespace literals {
 
-  inline Color operator"" _rgba(unsigned long long value) {
+  inline RGBAColor operator"" _rgba(unsigned long long value) {
     assert(value <= 0xFF'FF'FF'FF);
-    return Color{static_cast<uint32_t>(value)};
+    return RGBAColor{static_cast<uint32_t>(value)};
   }
 
 } // namespace literals
@@ -126,12 +126,12 @@ namespace literals {
 namespace std
 {
   template <>
-    struct tuple_size<mr::Color>
+    struct tuple_size<mr::RGBAColor>
       : std::integral_constant<size_t, 4> {};
 
   template <size_t I>
-    struct tuple_element<I, mr::Color> {
-      using type = mr::Color::ValueT;
+    struct tuple_element<I, mr::RGBAColor> {
+      using type = mr::RGBAColor::ValueT;
     };
 }
 #endif // __cpp_structured_bindings

--- a/mr-math.natvis
+++ b/mr-math.natvis
@@ -104,8 +104,8 @@
     <DisplayString>{_data} deg</DisplayString>
   </Type>
 
-  <!-- mr::Color -->
-  <Type Name="mr::Color">
+  <!-- mr::RGBAColor -->
+  <Type Name="mr::RGBAColor">
     <DisplayString>R={r()}, G={g()}, B={b()}, A={a()}}</DisplayString>
     <Expand>
       <Item Name="R">r()</Item>

--- a/tests/misc.cpp
+++ b/tests/misc.cpp
@@ -31,16 +31,16 @@ TEST(Transform, TransformVector) {
 
 // TODO: camera tests
 
-TEST(Color, Constructors) {
-  EXPECT_EQ(mr::Color(), mr::Color(0, 0, 0, 0));
+TEST(RGBAColor, Constructors) {
+  EXPECT_EQ(mr::RGBAColor(), mr::RGBAColor(0, 0, 0, 0));
 
-  const mr::Color expected1{0.3, 0.47, 0.8, 1.0};
-  EXPECT_EQ(mr::Color(0.3, 0.47, 0.8), expected1);
-  EXPECT_EQ(mr::Color(mr::Vec4f(0.3, 0.47, 0.8, 1)), expected1);
+  const mr::RGBAColor expected1{0.3, 0.47, 0.8, 1.0};
+  EXPECT_EQ(mr::RGBAColor(0.3, 0.47, 0.8), expected1);
+  EXPECT_EQ(mr::RGBAColor(mr::Vec4f(0.3, 0.47, 0.8, 1)), expected1);
 
-  const mr::Color expected2{0.2980392156862745, 0.4666666666666667, 0.8, 1.0};
-  EXPECT_EQ(mr::Color(76, 119, 204, 255), expected2);
-  EXPECT_EQ(mr::Color(0x4C'77'CC'FF), expected2);
+  const mr::RGBAColor expected2{0.2980392156862745, 0.4666666666666667, 0.8, 1.0};
+  EXPECT_EQ(mr::RGBAColor(76, 119, 204, 255), expected2);
+  EXPECT_EQ(mr::RGBAColor(0x4C'77'CC'FF), expected2);
   EXPECT_EQ(0x4C'77'CC'FF_rgba, expected2);
 }
 
@@ -74,7 +74,7 @@ TEST(Color, Setters) {
   auto color = 0x4C'77'CC'FF_rgba;
   color.r(1.0);
   color.set(1, 0.5);
-  EXPECT_EQ(color, mr::Color(1.0, 0.5, 0.8, 1.0));
+  EXPECT_EQ(color, mr::RGBAColor(1.0, 0.5, 0.8, 1.0));
 }
 
 TEST(Color, Equality) {
@@ -91,8 +91,8 @@ TEST(Color, Equality) {
 }
 
 TEST(Color, Addition) {
-  // Values can exeed 1.0 (should they?)
-  EXPECT_EQ(mr::Color(1.0, 0.0, 0.5, 1.0) + mr::Color(0.0, 1.0, 0.5, 1.0), mr::Color(1.0, 1.0, 1.0, 2.0));
+  // Values can exceed 1.0 (should they?)
+  EXPECT_EQ(mr::RGBAColor(1.0, 0.0, 0.5, 1.0) + mr::RGBAColor(0.0, 1.0, 0.5, 1.0), mr::RGBAColor(1.0, 1.0, 1.0, 2.0));
 }
 
 TEST(Utility, Within) {


### PR DESCRIPTION
- **Rename mr::Color to mr::RGBAColor**
- **Fix deprecated literal suffix syntax**
- **First color spaces implementation for mr::Color**
